### PR TITLE
Fix bug with dependency bigrams (with lemmas and lowercasing enabled)

### DIFF
--- a/corpus_toolkit_dev/corpus_tools.py
+++ b/corpus_toolkit_dev/corpus_tools.py
@@ -30,7 +30,7 @@ data_filename = pkg_resources.resource_filename('corpus_toolkit', 'antbnc_lemmas
 
 dirsep = os.path.sep
 default_punct_list = [",",".","?","'",'"',"!",":",";","(",")","[","]","''","``","--"] #we can add more items to this if needed
-default_space_list = ["\n","\t","	","   ","  "]
+default_space_list = ["\n","\t","    ","   ","  "]
 
 def doc_check(f_list,dirname,ending):
 	if len(f_list) == 0:
@@ -191,7 +191,7 @@ def write_corpus(new_dirname,corpus, dirname = False, ending = "txt"):
 		outf.flush()
 		outf.close()
 
-ignore_list = [""," ", "  ", "   ", "	"] #list of items we want to ignore in our frequency calculations
+ignore_list = [""," ", "  ", "   ", "    "]  #list of items we want to ignore in our frequency calculations
 
 def frequency(corpus_list, ignore = ignore_list, calc = 'freq', normed = False): #options for calc are 'freq' or 'range'
 	freq_dict = {} #empty dictionary

--- a/corpus_toolkit_dev/corpus_tools.py
+++ b/corpus_toolkit_dev/corpus_tools.py
@@ -30,7 +30,7 @@ data_filename = pkg_resources.resource_filename('corpus_toolkit', 'antbnc_lemmas
 
 dirsep = os.path.sep
 default_punct_list = [",",".","?","'",'"',"!",":",";","(",")","[","]","''","``","--"] #we can add more items to this if needed
-default_space_list = ["\n","\t","    ","   ","  "]
+default_space_list = ["\n","\t","	","   ","  "]
 
 def doc_check(f_list,dirname,ending):
 	if len(f_list) == 0:
@@ -191,7 +191,7 @@ def write_corpus(new_dirname,corpus, dirname = False, ending = "txt"):
 		outf.flush()
 		outf.close()
 
-ignore_list = [""," ", "  ", "   ", "    "] #list of items we want to ignore in our frequency calculations
+ignore_list = [""," ", "  ", "   ", "	"] #list of items we want to ignore in our frequency calculations
 
 def frequency(corpus_list, ignore = ignore_list, calc = 'freq', normed = False): #options for calc are 'freq' or 'range'
 	freq_dict = {} #empty dictionary
@@ -430,11 +430,12 @@ def dep_bigram(corpus,dep,lemma = True, lower = True, pron = False, dep_upos = N
 								dependent = token.text.lower() #then use the raw form of the word
 								headt = token.head.text.lower()
 							else:
-								dependent = token.lemma_
-								headt = token.head.lemma_
-						else:
-							dependent = token.lemma_
-							headt = token.head.lemma_
+								if lower:
+									dependent = token.lemma_.lower()
+									headt = token.head.lemma_.lower()
+								else:  # If lower is false, don't lower
+									dependent = token.lemma_
+									headt = token.head.lemma_
 					
 					if lemma == False: #if lemma is false, use the token form
 						if lower == True: #if lower is true, lower it

--- a/corpus_toolkit_dev/corpus_tools.py
+++ b/corpus_toolkit_dev/corpus_tools.py
@@ -430,12 +430,15 @@ def dep_bigram(corpus,dep,lemma = True, lower = True, pron = False, dep_upos = N
 								dependent = token.text.lower() #then use the raw form of the word
 								headt = token.head.text.lower()
 							else:
-								if lower:
+								if lower == True:
 									dependent = token.lemma_.lower()
 									headt = token.head.lemma_.lower()
 								else:  # If lower is false, don't lower
 									dependent = token.lemma_
 									headt = token.head.lemma_
+						else:  #if we want Spacy's pronoun lemma
+							dependent = token.lemma_
+							headt = token.head.lemma_
 					
 					if lemma == False: #if lemma is false, use the token form
 						if lower == True: #if lower is true, lower it


### PR DESCRIPTION
Hey Kris,

First of all, thanks so much for writing such a nice, easy-to-use tool for corpus analysis! I've been using it in some work I'm doing on studying gendered language in a news corpus, and it's been proving very useful so far. I especially like the dependency bigrams functionality - it's helping me a lot in interpreting linguistic content (far more than say, keyness or n-grams) in my specific corpus.

## Bug fix
I did notice that there was a bug when I try to run the dependency bigram function with **both** lemmas and lowercasing enabled. Instead of lowercasing the text once we obtain the lemma, it was simply returning the lemma regardless of whether or not the `lower=True` keyword was specified. The fix was simple - it's just an additional indented if-block as can be seen in the commit diff.

For example, I expect that when `lower=True` and `lemma=True` are both enabled, we should see something like this:

```
cup_win
canada_represent
```

However, with the current version, we get this:

```
Cup_win
Canada_represent
```

## Testing
I tested the fix out on multiple cases, and the `lower=True` keyword argument now works as intended. I just pushed the fix to the `dev` directory for now - let me know if this works or if you want it pushed to the main directory as well.

Thanks again for making this - I'm sure it'll be a useful resource for others in the field too. Cheers!